### PR TITLE
fix: add support for base URLs with path

### DIFF
--- a/src/client_async.rs
+++ b/src/client_async.rs
@@ -192,7 +192,18 @@ impl<T: AsyncTransport> JenkinsAsync<T> {
         };
         let (query, form) = (Self::own_pairs(query_raw), Self::own_pairs(form_raw));
 
-        let url = self.base.join(&ep.path())?;
+        let mut url = self.base.clone();
+        {
+            let mut url_path = url
+                .path_segments_mut()
+                .expect("Base URL should not be a cannot-be-a-base URL");
+
+            for p in ep.path().split('/') {
+                url_path.push(p);
+            }
+        }
+        let url = url;
+
         let (status, body) = self
             .transport
             .send(ep.method(), url.clone(), headers, query, form, self.timeout)

--- a/src/client_blocking.rs
+++ b/src/client_blocking.rs
@@ -196,7 +196,18 @@ impl<T: BlockingTransport> JenkinsBlocking<T> {
         };
         let (query, form) = (Self::own_pairs(query_raw), Self::own_pairs(form_raw));
 
-        let url = self.base.join(&ep.path())?;
+        let mut url = self.base.clone();
+        {
+            let mut url_path = url
+                .path_segments_mut()
+                .expect("Base URL should not be a cannot-be-a-base URL");
+
+            for p in ep.path().split('/') {
+                url_path.push(p);
+            }
+        }
+        let url = url;
+
         let (status, body) =
             self.transport
                 .send(ep.method(), url.clone(), headers, query, form, self.timeout)?;

--- a/src/middleware/crumb_async.rs
+++ b/src/middleware/crumb_async.rs
@@ -64,7 +64,18 @@ impl<T: AsyncTransport> CrumbAsync<T> {
 
     /// GET `/crumbIssuer/api/json` and return a fresh cache entry.
     async fn fetch_crumb(&self) -> Result<CachedCrumb, JenkinsError> {
-        let url = self.base_url.join("crumbIssuer/api/json")?;
+        let mut url = self.base_url.clone();
+        {
+            let mut url_path = url
+                .path_segments_mut()
+                .expect("Base URL should not be a cannot-be-a-base URL");
+
+            url_path.push("crumbIssuer");
+            url_path.push("api");
+            url_path.push("json");
+        }
+        let url = url;
+
         let url_for_error = url.clone(); // keep a copy for error context
 
         let mut hdrs = HashMap::new();

--- a/src/middleware/crumb_blocking.rs
+++ b/src/middleware/crumb_blocking.rs
@@ -54,7 +54,18 @@ impl<T: BlockingTransport> CrumbBlocking<T> {
     }
 
     fn fetch_crumb(&self) -> Result<CachedCrumb, JenkinsError> {
-        let url = self.base_url.join("crumbIssuer/api/json")?;
+        let mut url = self.base_url.clone();
+        {
+            let mut url_path = url
+                .path_segments_mut()
+                .expect("Base URL should not be a cannot-be-a-base URL");
+
+            url_path.push("crumbIssuer");
+            url_path.push("api");
+            url_path.push("json");
+        }
+        let url = url;
+
         let url_for_error = url.clone();
 
         let mut hdrs = HashMap::new();


### PR DESCRIPTION
If the base URL for jenkins has a path (which it does in my case) associated with it, the `.join` method on the Url struct overrides the path of base URL.